### PR TITLE
feat: upload images to aws

### DIFF
--- a/src/api/apiClient.tsx
+++ b/src/api/apiClient.tsx
@@ -1,0 +1,13 @@
+import axios from 'axios'
+
+// const BASE_URL = process.env.API_URL
+const BASE_URL = 'http://localhost:3050'
+
+// API client 설정
+export const apiClient = axios.create({
+  baseURL: BASE_URL,
+  timeout: 10000,
+  headers: {
+    'Content-Type': 'application/json'
+  }
+})

--- a/src/api/recruit/index.tsx
+++ b/src/api/recruit/index.tsx
@@ -1,0 +1,23 @@
+import { apiClient } from '@/api/apiClient'
+
+export const fetchPresignedUrl = async (fileName: string) => {
+  const response = await apiClient.post('/s3/presigned-url', {
+    fileName
+  })
+  return response.data
+}
+
+export const uploadImageToS3 = async (presignedUrl: string, file: File) => {
+  try {
+    await fetch(presignedUrl, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/pdf'
+      },
+      body: file
+    })
+  } catch (error) {
+    console.error('Failed to upload image', error)
+    throw error
+  }
+}

--- a/src/components/apply/Backend.tsx
+++ b/src/components/apply/Backend.tsx
@@ -32,9 +32,16 @@ const Backend = () => {
     // ✅ This will be type-safe and validated.
     console.log(values)
   }
-  const [file, setFile] = useState<File | null>(null)
-  const handleFileSelect = useCallback((file: File | null) => setFile(file), [])
-  const handleDeleteFile = useCallback(() => setFile(null), [])
+  const [fileName, setFileName] = useState<string | null>(null) // 저장되는 파일 이름 -> 나중에 DB에 보낼 값
+  const [originalFileName, setOriginalFileName] = useState<string | null>(null) // 화면에 표시되는, 원래 파일 이름
+  const handleFileSelect = useCallback((fileName: string, originalFileName: string) => {
+    setFileName(fileName)
+    setOriginalFileName(originalFileName)
+  }, [])
+  const handleDeleteFile = useCallback(() => {
+    setFileName(null)
+    setOriginalFileName(null)
+  }, [])
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
@@ -105,7 +112,12 @@ const Backend = () => {
         errors={errors}
         filed={'answer8'}
       />
-      <Portfolio file={file} handleDeleteFile={handleDeleteFile} handleFileSelect={handleFileSelect} />
+      <Portfolio
+        fileName={fileName}
+        originalFileName={originalFileName}
+        handleDeleteFile={handleDeleteFile}
+        handleFileSelect={handleFileSelect}
+      />
     </form>
   )
 }

--- a/src/components/apply/Designer.tsx
+++ b/src/components/apply/Designer.tsx
@@ -30,9 +30,16 @@ const Designer = () => {
     // ✅ This will be type-safe and validated.
     console.log(values)
   }
-  const [file, setFile] = useState<File | null>(null)
-  const handleFileSelect = useCallback((file: File | null) => setFile(file), [])
-  const handleDeleteFile = useCallback(() => setFile(null), [])
+  const [fileName, setFileName] = useState<string | null>(null) // 저장되는 파일 이름 -> 나중에 DB에 보낼 값
+  const [originalFileName, setOriginalFileName] = useState<string | null>(null) // 화면에 표시되는, 원래 파일 이름
+  const handleFileSelect = useCallback((fileName: string, originalFileName: string) => {
+    setFileName(fileName)
+    setOriginalFileName(originalFileName)
+  }, [])
+  const handleDeleteFile = useCallback(() => {
+    setFileName(null)
+    setOriginalFileName(null)
+  }, [])
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
@@ -89,7 +96,12 @@ const Designer = () => {
         errors={errors}
         filed={'answer6'}
       />
-      <Portfolio file={file} handleDeleteFile={handleDeleteFile} handleFileSelect={handleFileSelect} />
+      <Portfolio
+        fileName={fileName}
+        originalFileName={originalFileName}
+        handleDeleteFile={handleDeleteFile}
+        handleFileSelect={handleFileSelect}
+      />
     </form>
   )
 }

--- a/src/components/apply/FileUploadModal.tsx
+++ b/src/components/apply/FileUploadModal.tsx
@@ -1,15 +1,16 @@
 import { css } from '@styled-stytem/css'
 import { ChangeEvent, useState } from 'react'
 
+import { fetchPresignedUrl, uploadImageToS3 } from '@/api/recruit'
 import UploadIcon from '@/assets/UploadIcon.svg'
 
 interface FileUploadModalProps {
-  onChangeFile: (file: File | null) => void
+  onChangeFile: (fileName: string, originalFileName: string) => void
   handleClose: () => void
-  description?: string
 }
-const FileUploadModal = ({ onChangeFile, description, handleClose }: FileUploadModalProps) => {
+const FileUploadModal = ({ onChangeFile, handleClose }: FileUploadModalProps) => {
   const [dragOver, setDragOver] = useState(false)
+  const [file, setFile] = useState<File | null>(null)
 
   // 드래그 중인 요소가 목표 지점 진입할때
   const handleDragEnter = (e: React.DragEvent<HTMLLabelElement>) => {
@@ -39,19 +40,35 @@ const FileUploadModal = ({ onChangeFile, description, handleClose }: FileUploadM
 
     // 드래그되는 데이터 정보와 메서드를 제공하는 dataTransfer 객체 사용
     if (e.dataTransfer) {
-      const file = e.dataTransfer.files[0]
-      onChangeFile(file)
+      setFile(e.dataTransfer.files[0])
     }
   }
 
   // Drag & Drop이 아닌 클릭 이벤트로 업로드되는 기능도 추가
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files ? e.target.files[0] : null
-    onChangeFile(file)
-
+    setFile(e.target.files ? e.target.files[0] : null)
     // input 요소의 값 초기화
     e.target.value = ''
   }
+
+  const handleUpload = async () => {
+    if (!file) {
+      handleClose()
+      return
+    }
+    const fileName = `${Date.now()}-${Math.random().toString(36).substr(2, 9)}.pdf` // file name 생성
+    try {
+      // TODO: 진행중 스피너, 모달 등 추가
+      const presignedUrl = await fetchPresignedUrl(fileName)
+      await uploadImageToS3(presignedUrl, file)
+      onChangeFile(fileName, file.name)
+      handleClose()
+    } catch (error) {
+      // alert
+      alert('포트폴리오 업로드에 실패했습니다. 다시 시도해주세요.')
+    }
+  }
+
   return (
     <>
       <button
@@ -127,7 +144,7 @@ const FileUploadModal = ({ onChangeFile, description, handleClose }: FileUploadM
               color: '#676767'
             })}
           >
-            <p>Supported formates: JPEG, PNG, GIF, MP4, PDF, PSD, AI, Word, PPT</p>
+            <p>Supported formats: JPEG, PNG, GIF, MP4, PDF, PSD, AI, Word, PPT</p>
           </div>
           <input id="fileUpload" type="file" hidden onChange={handleChange} />
         </label>
@@ -143,7 +160,6 @@ const FileUploadModal = ({ onChangeFile, description, handleClose }: FileUploadM
             flexDir: 'column'
           })}
         >
-          Uploading
           <div
             className={css({
               display: 'flex',
@@ -154,7 +170,7 @@ const FileUploadModal = ({ onChangeFile, description, handleClose }: FileUploadM
               py: 2
             })}
           >
-            {description ?? 'your-file-here.PDF'}
+            {file ? file.name : 'your-file-here.PDF'}
           </div>
         </div>
         <button
@@ -173,7 +189,7 @@ const FileUploadModal = ({ onChangeFile, description, handleClose }: FileUploadM
             mt: 47,
             cursor: 'pointer'
           })}
-          onClick={handleClose}
+          onClick={handleUpload}
         >
           UPLOAD FILES
         </button>

--- a/src/components/apply/Frontend.tsx
+++ b/src/components/apply/Frontend.tsx
@@ -30,9 +30,16 @@ const Frontend = () => {
     // ✅ This will be type-safe and validated.
     console.log(values)
   }
-  const [file, setFile] = useState<File | null>(null)
-  const handleFileSelect = useCallback((file: File | null) => setFile(file), [])
-  const handleDeleteFile = useCallback(() => setFile(null), [])
+  const [fileName, setFileName] = useState<string | null>(null) // 저장되는 파일 이름 -> 나중에 DB에 보낼 값
+  const [originalFileName, setOriginalFileName] = useState<string | null>(null) // 화면에 표시되는, 원래 파일 이름
+  const handleFileSelect = useCallback((fileName: string, originalFileName: string) => {
+    setFileName(fileName)
+    setOriginalFileName(originalFileName)
+  }, [])
+  const handleDeleteFile = useCallback(() => {
+    setFileName(null)
+    setOriginalFileName(null)
+  }, [])
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
@@ -95,7 +102,12 @@ const Frontend = () => {
         errors={errors}
         filed={'answer7'}
       />
-      <Portfolio file={file} handleDeleteFile={handleDeleteFile} handleFileSelect={handleFileSelect} />
+      <Portfolio
+        fileName={fileName}
+        originalFileName={originalFileName}
+        handleDeleteFile={handleDeleteFile}
+        handleFileSelect={handleFileSelect}
+      />
     </form>
   )
 }

--- a/src/components/apply/Portfolio.tsx
+++ b/src/components/apply/Portfolio.tsx
@@ -9,11 +9,12 @@ import FileUploadModal from '@/components/apply/FileUploadModal'
 import Button from '@/components/ui/button'
 
 interface PortfolioProps {
-  file: File | null
-  handleFileSelect: (file: File | null) => void
+  fileName: string | null
+  originalFileName: string | null
+  handleFileSelect: (fileName: string, originalFileName: string) => void
   handleDeleteFile: () => void
 }
-const Portfolio = ({ file, handleFileSelect, handleDeleteFile }: PortfolioProps) => {
+const Portfolio = ({ fileName, originalFileName, handleFileSelect, handleDeleteFile }: PortfolioProps) => {
   const [isOpen, setIsOpen] = useState(false)
   const [deleteFile, setDeleteFile] = useState(false)
   const handleCloseModal = useCallback(() => setIsOpen(false), [])
@@ -44,11 +45,11 @@ const Portfolio = ({ file, handleFileSelect, handleDeleteFile }: PortfolioProps)
           파일 추가
           <Upload className={css({ w: 5, h: 5 })} />
         </Button>
-        {file && (
+        {originalFileName && (
           <div className={css({ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 1 })}>
             <Button variant="iconActive" size="icon" type="button" onClick={() => setDeleteFile(f => !f)}>
               <FileText className={css({ w: 5, h: 5 })} />
-              {file?.name}
+              {originalFileName}
             </Button>
             {deleteFile && (
               <motion.button
@@ -66,9 +67,7 @@ const Portfolio = ({ file, handleFileSelect, handleDeleteFile }: PortfolioProps)
         )}
       </div>
       {createPortal(
-        isOpen && (
-          <FileUploadModal onChangeFile={handleFileSelect} description={file?.name} handleClose={handleCloseModal} />
-        ),
+        isOpen && <FileUploadModal onChangeFile={handleFileSelect} handleClose={handleCloseModal} />,
         document.body
       )}
     </>

--- a/src/components/apply/ProjectManager.tsx
+++ b/src/components/apply/ProjectManager.tsx
@@ -28,9 +28,16 @@ const ProjectManager = () => {
     // ✅ This will be type-safe and validated.
     console.log(values)
   }
-  const [file, setFile] = useState<File | null>(null)
-  const handleFileSelect = useCallback((file: File | null) => setFile(file), [])
-  const handleDeleteFile = useCallback(() => setFile(null), [])
+  const [fileName, setFileName] = useState<string | null>(null) // 저장되는 파일 이름 -> 나중에 DB에 보낼 값
+  const [originalFileName, setOriginalFileName] = useState<string | null>(null) // 화면에 표시되는, 원래 파일 이름
+  const handleFileSelect = useCallback((fileName: string, originalFileName: string) => {
+    setFileName(fileName)
+    setOriginalFileName(originalFileName)
+  }, [])
+  const handleDeleteFile = useCallback(() => {
+    setFileName(null)
+    setOriginalFileName(null)
+  }, [])
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
@@ -73,7 +80,12 @@ const ProjectManager = () => {
         errors={errors}
         filed={'answer4'}
       />
-      <Portfolio file={file} handleDeleteFile={handleDeleteFile} handleFileSelect={handleFileSelect} />
+      <Portfolio
+        fileName={fileName}
+        originalFileName={originalFileName}
+        handleDeleteFile={handleDeleteFile}
+        handleFileSelect={handleFileSelect}
+      />
     </form>
   )
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 
@@ -5,8 +6,12 @@ import App from '@/App.tsx'
 
 import '@/index.css'
 
+const queryClient = new QueryClient()
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <BrowserRouter>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </BrowserRouter>
 )


### PR DESCRIPTION
## Why need this PR? 
- 목적 : 포트폴리오 파일을 S3에 업로드한다.
- 성공기준 : 포트폴리오 파일을 S3에 업로드하고 업로드된 파일명을 저장해둔다.


## Changes 
- axios및 tanstack-query setup
- S3 presignedUrl 가져오기 및 해당 URL로 포트폴리오 업로드 api 연동
- React에서 State로 파일을 저장하지 않고, AWS S3에 업로드된 fileName과 화면 표기되는 originalFileName만 저장
